### PR TITLE
Cleanup Istanbul ignores

### DIFF
--- a/src/fortnite-client.ts
+++ b/src/fortnite-client.ts
@@ -173,7 +173,6 @@ export class FortniteClient {
     });
   }
 
-  /* istanbul ignore next */
   private async onTokenExpired(token: AccessToken, secretKey: string): Promise<void> {
     const refreshedToken: AccessToken = await this.refreshToken(token, secretKey);
     switch (secretKey) {
@@ -203,7 +202,6 @@ export class FortniteClient {
     });
   }
 
-  /* istanbul ignore next */
   private async refreshToken(token: AccessToken, secretKey: string): Promise<AccessToken> {
     const tokenRequestConfig: IRequestRefreshTokenConfig = {
       grant_type: 'refresh_token',


### PR DESCRIPTION
- What's Changed?
1. Removed Istanbul ignore statements from two functions that should be tested in `fortnite-client.ts`

I only found these two instances where ignore shouldn't have been used, the rest of the usages would be testing the results of `class-transformer` or `setTimeout`. 

Fixes #9 